### PR TITLE
use older syntax for apt-add-repository

### DIFF
--- a/tools/setup/01-add-multiverse.sh
+++ b/tools/setup/01-add-multiverse.sh
@@ -13,11 +13,11 @@ sudo apt-get --assume-yes install python-software-properties
 
 # so use these lines:
 sudo apt-add-repository \
-    "http://archive.ubuntu.com/ubuntu precise multiverse"
+    "deb http://archive.ubuntu.com/ubuntu precise multiverse"
 sudo apt-add-repository \
-    "http://archive.ubuntu.com/ubuntu precise-updates multiverse"
+    "deb http://archive.ubuntu.com/ubuntu precise-updates multiverse"
 sudo apt-add-repository \
-    "http://archive.ubuntu.com/ubuntu precise-backports multiverse"
+    "deb http://archive.ubuntu.com/ubuntu precise-backports multiverse"
 sudo apt-add-repository \
-    "http://archive.ubuntu.com/ubuntu precise-security multiverse"
+    "deb http://archive.ubuntu.com/ubuntu precise-security multiverse"
 


### PR DESCRIPTION
the version of apt-add-repository on 12.10 does not support the syntax I first used.  
