### PR TITLE
Switch freenode webchat to https

### DIFF
--- a/website/frontend/templates/group.html
+++ b/website/frontend/templates/group.html
@@ -95,7 +95,7 @@ vim: set ts=2 sw=2 et sts=2 ai ft=htmldjango:
 
         <div id="chat-container" class="col-md-4">
           <div id="chat-sizer" class="sizer">
-            <iframe id="chat-frame" src="http://webchat.freenode.net?channels={{ config.ircchannel|urlencode }}&uio=MTA9dHJ1ZQ49"></iframe>
+            <iframe id="chat-frame" src="https://webchat.freenode.net?channels={{ config.ircchannel|urlencode }}&uio=MTA9dHJ1ZQ49"></iframe>
           </div>
         </div>
 </div>

--- a/website/frontend/templates/inroom.html
+++ b/website/frontend/templates/inroom.html
@@ -69,7 +69,7 @@ vim: set ts=2 sw=2 et sts=2 ai ft=htmldjango:
 <div class="row">
         <div id="chat-container" class="col-md-12">
           <div id="chat-sizer" class="sizer">
-            <iframe id="chat-frame" src="http://webchat.freenode.net?channels={{ config.ircchannel|urlencode }}&uio=MTA9dHJ1ZQ49"></iframe>
+            <iframe id="chat-frame" src="https://webchat.freenode.net?channels={{ config.ircchannel|urlencode }}&uio=MTA9dHJ1ZQ49"></iframe>
           </div>
         </div>
 </div>


### PR DESCRIPTION
Chrome doesn't like us including HTTP resources.  Lets use HTTPS instead.